### PR TITLE
Fix infinite loop on POLLHUP file descriptors

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -111,12 +111,6 @@ func newCodec() *codec {
 	}
 }
 
-func newReadCodec() *codec {
-	return &codec{
-		rbts: make([]byte, 2, maxHeaderSize-2),
-	}
-}
-
 func newWriteCodec() *codec {
 	return &codec{
 		wbts: make([]byte, maxHeaderSize),

--- a/conn.go
+++ b/conn.go
@@ -128,12 +128,7 @@ func (c *Conn) CloseWith(status CloseStatus, reason string, disconnect bool) err
 		// shutdown() to signal to the client the connection
 		// is being closed. conn.Close does not send a tcp FIN
 		// or FIN ACK packet. possibly a bug?)
-		fd, err := connectionFd(c.Conn)
-		if err != nil {
-			return err
-		}
-
-		return unix.Shutdown(fd, unix.SHUT_RDWR)
+		return unix.Shutdown(connectionFd(c.Conn), unix.SHUT_RDWR)
 	}
 
 	return nil
@@ -195,12 +190,7 @@ func (c *Conn) CloseImmediatelyWith(status CloseStatus, reason string, disconnec
 		// shutdown() to signal to the client the connection
 		// is being closed. conn.Close does not send a tcp FIN
 		// or FIN ACK packet. possibly a bug?)
-		fd, err := connectionFd(c.Conn)
-		if err != nil {
-			return err
-		}
-
-		return unix.Shutdown(fd, unix.SHUT_RDWR)
+		return unix.Shutdown(connectionFd(c.Conn), unix.SHUT_RDWR)
 	}
 
 	return nil

--- a/listener.go
+++ b/listener.go
@@ -178,7 +178,7 @@ func (l *listener) handleEvents() {
 }
 
 func (l *listener) read(fd int32, conn *Conn) error {
-	op, err := l.assembleFrame(int(fd), conn)
+	op, err := l.assembleFrame(conn)
 	if err != nil {
 		ce, ok := err.(*closeError)
 		if !ok {
@@ -250,7 +250,7 @@ func (l *listener) read(fd int32, conn *Conn) error {
 }
 
 // reads a frame and outputs its payload into a frame, text or binary buffer
-func (l *listener) assembleFrame(fd int, conn *Conn) (opCode, error) {
+func (l *listener) assembleFrame(conn *Conn) (opCode, error) {
 	l.framebuf.Reset()
 
 	err := conn.SetReadDeadline(time.Now().Add(l.readDeadline))
@@ -502,7 +502,7 @@ func (l *listener) kill(fd int) {
 		}
 	}
 
-	unix.Shutdown(fd, unix.SHUT_RDWR)
+	// unix.Shutdown(fd, unix.SHUT_RDWR)
 }
 
 func (l *listener) discard(length int64, cerr error) error {

--- a/server.go
+++ b/server.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -153,13 +154,7 @@ func (s *Server) Serve(port int) error {
 				return
 			}
 
-			cfd, err := connectionFd(conn)
-			if err != nil {
-				s.error(fmt.Errorf("failed to get ws file descriptor: %w", err), false)
-				return
-			}
-
-			l.register(cfd, conn)
+			l.register(connectionFd(conn), conn)
 		})
 
 		l.http = http.Server{
@@ -298,7 +293,12 @@ func acceptWs(w http.ResponseWriter, r *http.Request) (net.Conn, error) {
 	return conn, conn.SetDeadline(time.Time{})
 }
 
-func connectionFd(conn net.Conn) (int, error) {
-	fd, err := conn.(*net.TCPConn).File()
-	return int(fd.Fd()), err
+func connectionFd(conn net.Conn) int {
+	// get the poll file descriptor via reflect
+	// os.File().Fd() doesn't return this sadly
+	tcpConn := reflect.Indirect(reflect.ValueOf(conn)).FieldByName("conn")
+	fdVal := tcpConn.FieldByName("fd")
+	pfdVal := reflect.Indirect(fdVal).FieldByName("pfd")
+
+	return int(pfdVal.FieldByName("Sysfd").Int())
 }

--- a/server.go
+++ b/server.go
@@ -271,7 +271,7 @@ func acceptWs(w http.ResponseWriter, r *http.Request) (net.Conn, error) {
 
 		if o.Host != r.Host {
 			w.WriteHeader(http.StatusForbidden)
-			return nil, errors.New("Origin header does not match hostname")
+			return nil, errors.New("origin header does not match hostname")
 		}
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -572,6 +572,7 @@ func TestServerAutobahn(t *testing.T) {
 	var report testResults
 
 	err = json.Unmarshal(data, &report)
+	RequireNil(t, err)
 
 	for testcase, results := range report.UnknownServer {
 		waiter, _ := waiting.Load(testcase)


### PR DESCRIPTION
Fix infinite loop on POLLHUP file descriptors after they have been removed from the connection table but are not fully closed